### PR TITLE
「コメントを付けられるようにする」プラクティスの提出物

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,0 +1,24 @@
+.comments_list {
+  width: 1000px;
+}
+
+.comments_list ul {
+  list-style: none;
+}
+
+.comments_list li {
+  border-bottom: solid 1px lightgray;
+  padding: 0.5em 0;
+}
+
+.comments_list li:first-child {
+  border-top: solid 1px lightgray;
+}
+
+.comment_writer {
+  color: gray;
+}
+
+.comment_created_at {
+  color: gray;
+}

--- a/app/assets/stylesheets/reports.scss
+++ b/app/assets/stylesheets/reports.scss
@@ -18,3 +18,7 @@
 .report_writer {
   color: gray;
 }
+
+.report_created_at {
+  color: gray;
+}

--- a/app/assets/stylesheets/reports.scss
+++ b/app/assets/stylesheets/reports.scss
@@ -1,0 +1,20 @@
+.reports_list {
+  width: 1000px;
+}
+
+.reports_list ul {
+  list-style: none;
+}
+
+.reports_list li {
+  border-bottom: solid 1px lightgray;
+  padding: 1.5em 0;
+}
+
+.reports_list li:first-child {
+  border-top: solid 1px lightgray;
+}
+
+.report_writer {
+  color: gray;
+}

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Books::CommentsController < CommentsController
-  before_action :set_commentable
+  prepend_before_action :set_commentable
 
   private
 

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -12,7 +12,7 @@ class Books::CommentsController < CommentsController
   def render_when_unsaved
     @book = @commentable
     # books_controllerでセットされているインスタンス変数(@comment)が、空のコメントとして表示されないようにreloadする
-    @comments = @commentable.comments.reload
+    @comments = @commentable.comments.reload.order(:created_at)
 
     render 'books/show'
   end

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Books::CommentsController < CommentsController
+  before_action :set_commentable
+
+  private
+
+  def set_commentable
+    @commentable = Book.find(params[:book_id])
+  end
+
+  def render_when_unsaved
+    @book = @commentable
+    # books_controllerでセットされているインスタンス変数(@comment)が、空のコメントとして表示されないようにreloadする
+    @comments = @commentable.comments.reload
+
+    render 'books/show'
+  end
+end

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -11,8 +11,7 @@ class Books::CommentsController < CommentsController
 
   def render_when_unsaved
     @book = @commentable
-    # books_controllerでセットされているインスタンス変数(@comment)が、空のコメントとして表示されないようにreloadする
-    @comments = @commentable.comments.reload.order(:created_at)
+    @comments = @commentable.comments.order(:created_at)
 
     render 'books/show'
   end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -14,7 +14,7 @@ class BooksController < ApplicationController
   def show
     @comment = @book.comments.build
     # buildされたコメントが空のコメントとして表示されないようにreloadする
-    @comments = @book.comments.reload
+    @comments = @book.comments.reload.order(:created_at)
   end
 
   # GET /books/new

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -12,9 +12,8 @@ class BooksController < ApplicationController
   # GET /books/1
   # GET /books/1.json
   def show
-    @comment = @book.comments.build
-    # buildされたコメントが空のコメントとして表示されないようにreloadする
-    @comments = @book.comments.reload.order(:created_at)
+    @comment = Comment.new
+    @comments = @book.comments.order(:created_at)
   end
 
   # GET /books/new

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -11,7 +11,11 @@ class BooksController < ApplicationController
 
   # GET /books/1
   # GET /books/1.json
-  def show; end
+  def show
+    @comment = @book.comments.build
+    # buildされたコメントが空のコメントとして表示されないようにreloadする
+    @comments = @book.comments.reload
+  end
 
   # GET /books/new
   def new

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -26,6 +26,13 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    @comment = current_user.comments.find(params[:id])
+    @comment.destroy
+    flash[:notice] = t('controllers.common.notice_destroy', name: Comment.model_name.human)
+    redirect_to @commentable
+  end
+
   private
 
   def comment_params

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -19,7 +19,7 @@ class CommentsController < ApplicationController
     if @comment.update(comment_params)
       redirect_to @commentable, notice: t('controllers.common.notice_update', name: @comment.model_name.human)
     else
-      render 'edit'
+      render :edit
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,6 +11,21 @@ class CommentsController < ApplicationController
     end
   end
 
+  def edit
+    @comment = @commentable.comments.find(params[:id])
+    redirect_to @commentable unless @comment.user == current_user
+  end
+
+  def update
+    @comment = current_user.comments.find(params[:id])
+    if @comment.update(comment_params)
+      flash[:notice] = t('controllers.common.notice_update', name: @comment.model_name.human)
+      redirect_to @commentable
+    else
+      render 'edit'
+    end
+  end
+
   private
 
   def comment_params

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -36,6 +36,9 @@ class CommentsController < ApplicationController
 
   def set_comment
     @comment = @commentable.comments.find(params[:id])
-    redirect_to @commentable unless @comment.user == current_user
+    return if @comment.user == current_user
+
+    flash[:alert] = t('views.common.not_permitted')
+    redirect_to @commentable
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CommentsController < ApplicationController
+  def create
+    @comment = @commentable.comments.build(comment_params)
+
+    if @comment.save
+      redirect_to @commentable, notice: t('controllers.common.notice_create', name: @comment.model_name.human)
+    else
+      render_when_unsaved
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content).merge(user_id: current_user.id)
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,8 +17,7 @@ class CommentsController < ApplicationController
 
   def update
     if @comment.update(comment_params)
-      flash[:notice] = t('controllers.common.notice_update', name: @comment.model_name.human)
-      redirect_to @commentable
+      redirect_to @commentable, notice: t('controllers.common.notice_update', name: @comment.model_name.human)
     else
       render 'edit'
     end
@@ -26,8 +25,7 @@ class CommentsController < ApplicationController
 
   def destroy
     @comment.destroy
-    flash[:notice] = t('controllers.common.notice_destroy', name: Comment.model_name.human)
-    redirect_to @commentable
+    redirect_to @commentable, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CommentsController < ApplicationController
+  before_action :set_comment, only: %i[edit update destroy]
+
   def create
     @comment = @commentable.comments.build(comment_params)
 
@@ -11,13 +13,9 @@ class CommentsController < ApplicationController
     end
   end
 
-  def edit
-    @comment = @commentable.comments.find(params[:id])
-    redirect_to @commentable unless @comment.user == current_user
-  end
+  def edit; end
 
   def update
-    @comment = current_user.comments.find(params[:id])
     if @comment.update(comment_params)
       flash[:notice] = t('controllers.common.notice_update', name: @comment.model_name.human)
       redirect_to @commentable
@@ -27,7 +25,6 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    @comment = current_user.comments.find(params[:id])
     @comment.destroy
     flash[:notice] = t('controllers.common.notice_destroy', name: Comment.model_name.human)
     redirect_to @commentable
@@ -37,5 +34,10 @@ class CommentsController < ApplicationController
 
   def comment_params
     params.require(:comment).permit(:content).merge(user_id: current_user.id)
+  end
+
+  def set_comment
+    @comment = @commentable.comments.find(params[:id])
+    redirect_to @commentable unless @comment.user == current_user
   end
 end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Reports::CommentsController < CommentsController
-  before_action :set_commentable
+  prepend_before_action :set_commentable
 
   private
 

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -11,8 +11,7 @@ class Reports::CommentsController < CommentsController
 
   def render_when_unsaved
     @report = @commentable
-    # reports_controllerでセットされているインスタンス変数(@comment)が、空のコメントとして表示されないようにreloadする
-    @comments = @commentable.comments.reload.order(:created_at)
+    @comments = @commentable.comments.order(:created_at)
 
     render 'reports/show'
   end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Reports::CommentsController < CommentsController
+  before_action :set_commentable
+
+  private
+
+  def set_commentable
+    @commentable = Report.find(params[:report_id])
+  end
+
+  def render_when_unsaved
+    @report = @commentable
+    # reports_controllerでセットされているインスタンス変数(@comment)が、空のコメントとして表示されないようにreloadする
+    @comments = @commentable.comments.reload
+
+    render 'reports/show'
+  end
+end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -12,7 +12,7 @@ class Reports::CommentsController < CommentsController
   def render_when_unsaved
     @report = @commentable
     # reports_controllerでセットされているインスタンス変数(@comment)が、空のコメントとして表示されないようにreloadする
-    @comments = @commentable.comments.reload
+    @comments = @commentable.comments.reload.order(:created_at)
 
     render 'reports/show'
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -24,7 +24,7 @@ class ReportsController < ApplicationController
     if @report.save
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
-      render 'new'
+      render :new
     end
   end
 
@@ -32,7 +32,7 @@ class ReportsController < ApplicationController
     if @report.update(report_params)
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
-      render 'edit'
+      render :edit
     end
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,4 +1,5 @@
 class ReportsController < ApplicationController
+  before_action :set_report, only: %i[edit update destroy]
 
   def index
     @reports = Report.order(id: 'DESC').page(params[:page]).per(10)
@@ -12,9 +13,7 @@ class ReportsController < ApplicationController
     @report = current_user.reports.build
   end
 
-  def edit
-    @report = current_user.reports.find(params[:id])
-  end
+  def edit; end
 
   def create
     @report = current_user.reports.build(report_params)
@@ -27,8 +26,6 @@ class ReportsController < ApplicationController
   end
 
   def update
-    @report = current_user.reports.find(params[:id])
-
     if @report.update(report_params)
       flash[:notice] = t('controllers.common.notice_update', name: Report.model_name.human)
       redirect_to @report
@@ -38,7 +35,6 @@ class ReportsController < ApplicationController
   end
 
   def destroy
-    @report = current_user.reports.find(params[:id])
     @report.destroy
 
     flash[:notice] = t('controllers.common.notice_destroy', name: Report.model_name.human)
@@ -49,5 +45,9 @@ class ReportsController < ApplicationController
 
   def report_params
     params.require(:report).permit(:title, :content)
+  end
+
+  def set_report
+    @report = current_user.reports.find(params[:id])
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,26 @@
+class ReportsController < ApplicationController
+
+  def show
+    @report = Report.find(params[:id])
+  end
+
+  def new
+    @report = current_user.reports.build
+  end
+
+  def create
+    @report = current_user.reports.build(report_params)
+    if @report.save
+      flash[:notice] = t('controllers.common.notice_create', name: Report.model_name.human)
+      redirect_to @report
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+  def report_params
+    params.require(:report).permit(:title, :content)
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,6 +12,10 @@ class ReportsController < ApplicationController
     @report = current_user.reports.build
   end
 
+  def edit
+    @report = current_user.reports.find(params[:id])
+  end
+
   def create
     @report = current_user.reports.build(report_params)
     if @report.save
@@ -19,6 +23,17 @@ class ReportsController < ApplicationController
       redirect_to @report
     else
       render 'new'
+    end
+  end
+
+  def update
+    @report = current_user.reports.find(params[:id])
+
+    if @report.update(report_params)
+      flash[:notice] = t('controllers.common.notice_update', name: Report.model_name.human)
+      redirect_to @report
+    else
+      render 'edit'
     end
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -11,7 +11,7 @@ class ReportsController < ApplicationController
     @report = Report.find(params[:id])
     @comment = @report.comments.build
     # buildされたコメントが空のコメントとして表示されないようにreloadする
-    @comments = @report.comments.reload
+    @comments = @report.comments.reload.order(:created_at)
   end
 
   def new

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -4,7 +4,7 @@ class ReportsController < ApplicationController
   before_action :set_report, only: %i[edit update destroy]
 
   def index
-    @reports = Report.order(id: 'DESC').page(params[:page]).per(10)
+    @reports = Report.order(id: :desc).page(params[:page]).per(10)
   end
 
   def show

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -23,8 +23,7 @@ class ReportsController < ApplicationController
   def create
     @report = current_user.reports.build(report_params)
     if @report.save
-      flash[:notice] = t('controllers.common.notice_create', name: Report.model_name.human)
-      redirect_to @report
+      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
       render 'new'
     end
@@ -32,8 +31,7 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
-      flash[:notice] = t('controllers.common.notice_update', name: Report.model_name.human)
-      redirect_to @report
+      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render 'edit'
     end
@@ -42,8 +40,7 @@ class ReportsController < ApplicationController
   def destroy
     @report.destroy
 
-    flash[:notice] = t('controllers.common.notice_destroy', name: Report.model_name.human)
-    redirect_to reports_path
+    redirect_to reports_path, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -37,6 +37,14 @@ class ReportsController < ApplicationController
     end
   end
 
+  def destroy
+    @report = current_user.reports.find(params[:id])
+    @report.destroy
+
+    flash[:notice] = t('controllers.common.notice_destroy', name: Report.model_name.human)
+    redirect_to reports_path
+  end
+
   private
 
   def report_params

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[edit update destroy]
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -9,9 +9,8 @@ class ReportsController < ApplicationController
 
   def show
     @report = Report.find(params[:id])
-    @comment = @report.comments.build
-    # buildされたコメントが空のコメントとして表示されないようにreloadする
-    @comments = @report.comments.reload.order(:created_at)
+    @comment = Comment.new
+    @comments = @report.comments.order(:created_at)
   end
 
   def new

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,9 @@
 class ReportsController < ApplicationController
 
+  def index
+    @reports = Report.order(id: 'DESC').page(params[:page]).per(10)
+  end
+
   def show
     @report = Report.find(params[:id])
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -7,6 +7,9 @@ class ReportsController < ApplicationController
 
   def show
     @report = Report.find(params[:id])
+    @comment = @report.comments.build
+    # buildされたコメントが空のコメントとして表示されないようにreloadする
+    @comments = @report.comments.reload
   end
 
   def new

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -3,6 +3,6 @@
 class Users::ReportsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @reports = @user.reports.order(id: 'DESC').page(params[:page]).per(10)
+    @reports = @user.reports.order(id: :desc).page(params[:page]).per(10)
   end
 end

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Users::ReportsController < ApplicationController
+  def index
+    @user = User.find(params[:user_id])
+    @reports = @user.reports.order(id: 'DESC').page(params[:page]).per(10)
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,6 @@
 
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
+
+  has_many :comments, as: :commentable, dependent: :destroy
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,3 @@
+class Comment < ApplicationRecord
+  belongs_to :commentable, polymorphic: true
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true
   belongs_to :user

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true
+  belongs_to :user
+
+  validates :content, presence: true
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,5 +1,6 @@
 class Report < ApplicationRecord
   belongs_to :user
+  has_many :comments, as: :commentable, dependent: :destroy
 
   validates :title, :content, presence: true
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,5 @@
+class Report < ApplicationRecord
+  belongs_to :user
+
+  validates :title, :content, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
 
   has_one_attached :avatar
 
+  has_many :reports, dependent: :destroy
+
   def following?(user)
     active_relationships.where(following_id: user.id).exists?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_one_attached :avatar
 
   has_many :reports, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   def following?(user)
     active_relationships.where(following_id: user.id).exists?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,6 @@ class User < ApplicationRecord
   end
 
   def name_or_email
-    attribute_present?(:name) ? self.name : self.email
+    attribute_present?(:name) ? name : email
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,4 +31,8 @@ class User < ApplicationRecord
     relationship = active_relationships.find_by(following_id: user.id)
     relationship&.destroy!
   end
+
+  def name_or_email
+    attribute_present?(:name) ? self.name : self.email
+  end
 end

--- a/app/views/books/comments/edit.html.erb
+++ b/app/views/books/comments/edit.html.erb
@@ -1,25 +1,3 @@
 <h1><% t('views.common.edit', name: @comment.model_name.human) %></h1>
 
-<%= form_with(model: @comment, url: book_comment_path(@commentable, @comment), local: true) do |form| %>
-  <% if @comment.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t 'errors.template.header', model: @comment.model_name.human, count: @comment.errors.count %></h2>
-
-      <ul>
-        <% @comment.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= form.label :content %>
-    <%= form.text_area :content, required: true, size: '50x5' %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit t('helpers.submit.update') %>
-  </div>
-<% end %>
-
+<%= render partial: 'shared/comment_form', locals: { comment: @comment, commentable: @commentable, button_text: t('helpers.submit.update') } %>

--- a/app/views/books/comments/edit.html.erb
+++ b/app/views/books/comments/edit.html.erb
@@ -1,0 +1,25 @@
+<h1><% t('views.common.edit', name: @comment.model_name.human) %></h1>
+
+<%= form_with(model: @comment, url: book_comment_path(@commentable, @comment), local: true) do |form| %>
+  <% if @comment.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= t 'errors.template.header', model: @comment.model_name.human, count: @comment.errors.count %></h2>
+
+      <ul>
+        <% @comment.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content, required: true, size: '50x5' %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit t('helpers.submit.update') %>
+  </div>
+<% end %>
+

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -35,6 +35,9 @@
         <p class="comment_writer"><%= comment.user.attribute_present?(:name) ? comment.user.name : comment.user.email %></p>
         <p><%= comment.content %></p>
         <span class="comment_created_at"><%= l(comment.created_at, format: :long)%></span>
+        <% if comment.user == current_user %>
+          <%= link_to t('views.common.edit'), edit_book_comment_path(@book, comment) %>
+        <% end %>
       </li>
     <% end %>
     </ul>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -22,3 +22,44 @@
 
 <%= link_to t('views.common.edit'), edit_book_path(@book) %> |
 <%= link_to t('views.common.back'), books_path %>
+
+<h2><%= @comments.model_name.human %></h2>
+
+<div class="comments_list">
+  <% if @comments.empty? %>
+    <p><%= t('users.comments.nothing') %></p>
+  <% else %>
+    <ul>
+    <% @comments.each do |comment| %>
+      <li>
+        <p class="comment_writer"><%= comment.user.attribute_present?(:name) ? comment.user.name : comment.user.email %></p>
+        <p><%= comment.content %></p>
+        <span class="comment_created_at"><%= l(comment.created_at, format: :long)%></span>
+      </li>
+    <% end %>
+    </ul>
+  <% end %>
+</div>
+
+<%= form_with(model: @comment, url: book_comments_path(@book), local: true) do |form| %>
+  <% if @comment.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= t 'errors.template.header', model: @comment.model_name.human, count: @comment.errors.count %></h2>
+
+      <ul>
+        <% @comment.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content, required: true, size: '50x5' %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit t('users.comments.create') %>
+  </div>
+<% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -25,6 +25,6 @@
 
 <h2><%= @comments.model_name.human %></h2>
 
-<%= render partial: 'shared/comment_list' locals: { commentable: @book }%>
+<%= render partial: 'shared/comment_list' locals: { commentable: @book } %>
 
 <%= render partial: 'shared/comment_form', locals: { comment: @comment, commentable: @book, button_text: t('users.comments.create') } %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -25,24 +25,6 @@
 
 <h2><%= @comments.model_name.human %></h2>
 
-<div class="comments_list">
-  <% if @comments.empty? %>
-    <p><%= t('users.comments.nothing') %></p>
-  <% else %>
-    <ul>
-    <% @comments.each do |comment| %>
-      <li>
-        <p class="comment_writer"><%= comment.user.attribute_present?(:name) ? comment.user.name : comment.user.email %></p>
-        <p><%= comment.content %></p>
-        <span class="comment_created_at"><%= l(comment.created_at, format: :long)%></span>
-        <% if comment.user == current_user %>
-          <%= link_to t('views.common.edit'), edit_book_comment_path(@book, comment) %>
-          <%= link_to t('views.common.destroy'), book_comment_path(@book, comment), method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
-        <% end %>
-      </li>
-    <% end %>
-    </ul>
-  <% end %>
-</div>
+<%= render partial: 'shared/comment_list' locals: { commentable: @book }%>
 
 <%= render partial: 'shared/comment_form', locals: { comment: @comment, commentable: @book, button_text: t('users.comments.create') } %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -45,25 +45,4 @@
   <% end %>
 </div>
 
-<%= form_with(model: @comment, url: book_comments_path(@book), local: true) do |form| %>
-  <% if @comment.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t 'errors.template.header', model: @comment.model_name.human, count: @comment.errors.count %></h2>
-
-      <ul>
-        <% @comment.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= form.label :content %>
-    <%= form.text_area :content, required: true, size: '50x5' %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit t('users.comments.create') %>
-  </div>
-<% end %>
+<%= render partial: 'shared/comment_form', locals: { comment: @comment, commentable: @book, button_text: t('users.comments.create') } %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -37,6 +37,7 @@
         <span class="comment_created_at"><%= l(comment.created_at, format: :long)%></span>
         <% if comment.user == current_user %>
           <%= link_to t('views.common.edit'), edit_book_comment_path(@book, comment) %>
+          <%= link_to t('views.common.destroy'), book_comment_path(@book, comment), method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
         <% end %>
       </li>
     <% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -25,6 +25,6 @@
 
 <h2><%= @comments.model_name.human %></h2>
 
-<%= render partial: 'shared/comment_list' locals: { commentable: @book } %>
+<%= render partial: 'shared/comment_list', locals: { commentable: @book } %>
 
 <%= render partial: 'shared/comment_form', locals: { comment: @comment, commentable: @book, button_text: t('users.comments.create') } %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -3,8 +3,7 @@
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
+                 resource: resource.class.model_name.human.downcase) %>
     </h2>
     <ul>
       <% resource.errors.full_messages.each do |message| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,9 @@
           <li>
             <%= link_to User.model_name.human, users_path %>
           </li>
+          <li>
+            <%= link_to Report.model_name.human, reports_path %>
+          </li>
         </ul>
         <div class="title"><%= t('.sign_in_as', email: current_user.email) %></div>
         <ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,9 @@
             <%= link_to t('devise.registrations.edit.title'), edit_user_registration_path %>
           </li>
           <li>
+            <%= link_to t('users.reports.new.title'), new_report_path %>
+          </li>
+          <li>
             <%= link_to t('views.common.sign_out'), destroy_user_session_path, method: :delete %>
           </li>
         </ul>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: report, local: true) do |form| %>
+  <% if report.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= t 'errors.template.header', model: report.model_name.human, count: report.errors.count %> </h2>
+
+      <ul>
+        <% report.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content, size: '50x12' %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -13,12 +13,12 @@
 
   <div class="field">
     <%= form.label :title %>
-    <%= form.text_field :title %>
+    <%= form.text_field :title, required: true %>
   </div>
 
   <div class="field">
     <%= form.label :content %>
-    <%= form.text_area :content, size: '50x12' %>
+    <%= form.text_area :content, required: true, size: '50x12' %>
   </div>
 
   <div class="actions">

--- a/app/views/reports/comments/edit.html.erb
+++ b/app/views/reports/comments/edit.html.erb
@@ -1,0 +1,24 @@
+<h1><% t('views.common.edit', name: @comment.model_name.human) %></h1>
+
+<%= form_with(model: @comment, url: report_comment_path(@commentable, @comment), local: true) do |form| %>
+  <% if @comment.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= t 'errors.template.header', model: @comment.model_name.human, count: @comment.errors.count %></h2>
+
+      <ul>
+        <% @comment.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content, required: true, size: '50x5' %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit t('helpers.submit.update') %>
+  </div>
+<% end %>

--- a/app/views/reports/comments/edit.html.erb
+++ b/app/views/reports/comments/edit.html.erb
@@ -1,24 +1,3 @@
 <h1><% t('views.common.edit', name: @comment.model_name.human) %></h1>
 
-<%= form_with(model: @comment, url: report_comment_path(@commentable, @comment), local: true) do |form| %>
-  <% if @comment.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t 'errors.template.header', model: @comment.model_name.human, count: @comment.errors.count %></h2>
-
-      <ul>
-        <% @comment.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= form.label :content %>
-    <%= form.text_area :content, required: true, size: '50x5' %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit t('helpers.submit.update') %>
-  </div>
-<% end %>
+<%= render partial: 'shared/comment_form', locals: { comment: @comment, commentable: @commentable, button_text: t('helpers.submit.update') } %>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,0 +1,29 @@
+<h1><%= t('views.common.title_edit', name: @report.model_name.human) %></h1>
+
+<%= form_with model: @report do |form| %>
+  <% if @report.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= t 'errors.template.header', model: @report.model_name.human, count: @report.errors.count %> </h2>
+
+      <ul>
+        <% @report.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,29 +1,3 @@
 <h1><%= t('views.common.title_edit', name: @report.model_name.human) %></h1>
 
-<%= form_with model: @report do |form| %>
-  <% if @report.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t 'errors.template.header', model: @report.model_name.human, count: @report.errors.count %> </h2>
-
-      <ul>
-        <% @report.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= form.label :title %>
-    <%= form.text_field :title %>
-  </div>
-
-  <div class="field">
-    <%= form.label :content %>
-    <%= form.text_area :content %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
-  </div>
-<% end %>
+<%= render 'form', report: @report %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -6,7 +6,7 @@
     <li>
       <p><%= link_to report.title, report %></p>
       <span class="report_writer"><%= report.user.attribute_present?(:name) ? report.user.name : report.user.email %></span>
-      <span class="report_created_at"><%= l(report.created_at, format: :date_only)%> の日報</span>
+      <span class="report_created_at"><%= l(report.created_at, format: :date_only) %> の日報</span>
     </li>
     <% end %>
   </ul>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,16 @@
+<h1><%= @reports.model_name.human %></h1>
+
+<div class="reports_list">
+  <ul>
+    <% @reports.each do |report| %>
+    <li>
+      <%= link_to report.title, report %>
+      <span class="report_writer"><%= report.user.name%></span>
+    </li>
+    <% end %>
+  </ul>
+</div>
+
+<div>
+  <%= paginate @reports %>
+</div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -5,7 +5,7 @@
     <% @reports.each do |report| %>
     <li>
       <p><%= link_to report.title, report %></p>
-      <span class="report_writer"><%= report.user.attribute_present?(:name) ? report.user.name : report.user.email %></span>
+      <span class="report_writer"><%= report.user.name_or_email %></span>
       <span class="report_created_at"><%= l(report.created_at, format: :date_only) %> の日報</span>
     </li>
     <% end %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -4,8 +4,9 @@
   <ul>
     <% @reports.each do |report| %>
     <li>
-      <%= link_to report.title, report %>
-      <span class="report_writer"><%= report.user.name%></span>
+      <p><%= link_to report.title, report %></p>
+      <span class="report_writer"><%= report.user.attribute_present?(:name) ? report.user.name : report.user.email %></span>
+      <span class="report_created_at"><%= l(report.created_at, format: :date_only)%> の日報</span>
     </li>
     <% end %>
   </ul>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,29 +1,3 @@
 <h1><%= t('views.common.title_new', name: @report.model_name.human) %></h1>
 
-<%= form_with model: @report do |form| %>
-  <% if @report.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t 'errors.template.header', model: @report.model_name.human, count: @report.errors.count %> </h2>
-
-      <ul>
-        <% @report.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= form.label :title %>
-    <%= form.text_field :title %>
-  </div>
-
-  <div class="field">
-    <%= form.label :content %>
-    <%= form.text_area :content %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
-  </div>
-<% end %>
+<%= render 'form', report: @report %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,0 +1,29 @@
+<h1><%= t('views.common.title_new', name: @report.model_name.human) %></h1>
+
+<%= form_with model: @report do |form| %>
+  <% if @report.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= t 'errors.template.header', model: @report.model_name.human, count: @report.errors.count %> </h2>
+
+      <ul>
+        <% @report.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -10,7 +10,7 @@
 <% if @report.user == current_user %>
   <div>
     <%= link_to t('views.common.edit'), edit_report_path(@report) %> |
-    <%= link_to t('views.common.destroy'), report_path, method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
+    <%= link_to t('views.common.destroy'), @report, method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
   </div>
 <% end %>
 

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -26,6 +26,9 @@
         <p class="comment_writer"><%= comment.user.attribute_present?(:name) ? comment.user.name : comment.user.email %></p>
         <p><%= comment.content %></p>
         <span class="comment_created_at"><%= l(comment.created_at, format: :long)%></span>
+        <% if comment.user == current_user %>
+          <%= link_to t('views.common.edit'), edit_report_comment_path(@report, comment) %>
+        <% end %>
       </li>
     <% end %>
     </ul>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,7 +1,9 @@
 <h1><%= @report.title %></h1>
 
-<p><%= @report.user.name %>さんの日報</p>
-<span>投稿日 : <%= l(@report.created_at, format: :date_only) %></span>
+<div class="report_information">
+  <span><%= t Report.human_attribute_name(:user_id) %> : <%= @report.user.name_or_email %></span>
+  <span><%= t Report.human_attribute_name(:created_at) %> : <%= l(@report.created_at, format: :date_only) %></span>
+</div>
 
 <div class="report_content">
   <%= @report.content %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -13,3 +13,44 @@
     <%= link_to t('views.common.destroy'), report_path, method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
   </div>
 <% end %>
+
+<h2><%= @comments.model_name.human %></h2>
+
+<div class="comments_list">
+  <% if @comments.empty? %>
+    <p><%= t('users.comments.nothing') %></p>
+  <% else %>
+    <ul>
+    <% @comments.each do |comment| %>
+      <li>
+        <p class="comment_writer"><%= comment.user.attribute_present?(:name) ? comment.user.name : comment.user.email %></p>
+        <p><%= comment.content %></p>
+        <span class="comment_created_at"><%= l(comment.created_at, format: :long)%></span>
+      </li>
+    <% end %>
+    </ul>
+  <% end %>
+</div>
+
+<%= form_with(model: @comment, url: report_comments_path(@report), local: true) do |form| %>
+  <% if @comment.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= t 'errors.template.header', model: @comment.model_name.human, count: @comment.errors.count %></h2>
+
+      <ul>
+        <% @comment.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content, required: true, size: '50x5' %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit t('users.comments.create') %>
+  </div>
+<% end %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -16,24 +16,6 @@
 
 <h2><%= @comments.model_name.human %></h2>
 
-<div class="comments_list">
-  <% if @comments.empty? %>
-    <p><%= t('users.comments.nothing') %></p>
-  <% else %>
-    <ul>
-    <% @comments.each do |comment| %>
-      <li>
-        <p class="comment_writer"><%= comment.user.attribute_present?(:name) ? comment.user.name : comment.user.email %></p>
-        <p><%= comment.content %></p>
-        <span class="comment_created_at"><%= l(comment.created_at, format: :long)%></span>
-        <% if comment.user == current_user %>
-          <%= link_to t('views.common.edit'), edit_report_comment_path(@report, comment) %>
-          <%= link_to t('views.common.destroy'), report_comment_path(@report, comment), method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
-        <% end %>
-      </li>
-    <% end %>
-    </ul>
-  <% end %>
-</div>
+<%= render partial: 'shared/comment_list', locals: { commentable: @report } %>
 
 <%= render partial: 'shared/comment_form', locals: { comment: @comment, commentable: @report, button_text: t('users.comments.create') } %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -8,5 +8,8 @@
 </div>
 
 <% if @report.user == current_user %>
-  <div><%= link_to t('views.common.edit'), edit_report_path(@report) %></div>
+  <div>
+    <%= link_to t('views.common.edit'), edit_report_path(@report) %> |
+    <%= link_to t('views.common.destroy'), report_path, method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
+  </div>
 <% end %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -36,25 +36,4 @@
   <% end %>
 </div>
 
-<%= form_with(model: @comment, url: report_comments_path(@report), local: true) do |form| %>
-  <% if @comment.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t 'errors.template.header', model: @comment.model_name.human, count: @comment.errors.count %></h2>
-
-      <ul>
-        <% @comment.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= form.label :content %>
-    <%= form.text_area :content, required: true, size: '50x5' %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit t('users.comments.create') %>
-  </div>
-<% end %>
+<%= render partial: 'shared/comment_form', locals: { comment: @comment, commentable: @report, button_text: t('users.comments.create') } %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -28,6 +28,7 @@
         <span class="comment_created_at"><%= l(comment.created_at, format: :long)%></span>
         <% if comment.user == current_user %>
           <%= link_to t('views.common.edit'), edit_report_comment_path(@report, comment) %>
+          <%= link_to t('views.common.destroy'), report_comment_path(@report, comment), method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
         <% end %>
       </li>
     <% end %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,8 @@
+<h1><%= @report.title %></h1>
+
+<p><%= @report.user.name %>さんの日報</p>
+<span>投稿日 : <%= l(@report.created_at, format: :date_only) %></span>
+
+<div class="report_content">
+  <%= @report.content %>
+</div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -6,3 +6,7 @@
 <div class="report_content">
   <%= @report.content %>
 </div>
+
+<% if @report.user == current_user %>
+  <div><%= link_to t('views.common.edit'), edit_report_path(@report) %></div>
+<% end %>

--- a/app/views/shared/_comment_form.html.erb
+++ b/app/views/shared/_comment_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: comment, url: polymorphic_url([commentable, comment]), local: true) do |form| %>
+  <% if comment.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= t 'errors.template.header', model: comment.model_name.human, count: comment.errors.count %></h2>
+
+      <ul>
+        <% comment.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content, required: true, size: '50x5' %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit button_text %>
+  </div>
+<% end %>

--- a/app/views/shared/_comment_list.html.erb
+++ b/app/views/shared/_comment_list.html.erb
@@ -5,7 +5,7 @@
     <ul>
     <% @comments.each do |comment| %>
       <li>
-        <p class="comment_writer"><%= comment.user.attribute_present?(:name) ? comment.user.name : comment.user.email %></p>
+        <p class="comment_writer"><%= comment.user.name_or_email %></p>
         <p><%= comment.content %></p>
         <span class="comment_created_at"><%= l(comment.created_at, format: :long) %></span>
         <% if comment.user == current_user %>

--- a/app/views/shared/_comment_list.html.erb
+++ b/app/views/shared/_comment_list.html.erb
@@ -1,0 +1,19 @@
+<div class="comments_list">
+  <% if @comments.empty? %>
+    <p><%= t('users.comments.nothing') %></p>
+  <% else %>
+    <ul>
+    <% @comments.each do |comment| %>
+      <li>
+        <p class="comment_writer"><%= comment.user.attribute_present?(:name) ? comment.user.name : comment.user.email %></p>
+        <p><%= comment.content %></p>
+        <span class="comment_created_at"><%= l(comment.created_at, format: :long)%></span>
+        <% if comment.user == current_user %>
+          <%= link_to t('views.common.edit'), polymorphic_url([commentable, comment], action: :edit) %>
+          <%= link_to t('views.common.destroy'), polymorphic_url([commentable, comment]), method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
+        <% end %>
+      </li>
+    <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/shared/_comment_list.html.erb
+++ b/app/views/shared/_comment_list.html.erb
@@ -7,7 +7,7 @@
       <li>
         <p class="comment_writer"><%= comment.user.attribute_present?(:name) ? comment.user.name : comment.user.email %></p>
         <p><%= comment.content %></p>
-        <span class="comment_created_at"><%= l(comment.created_at, format: :long)%></span>
+        <span class="comment_created_at"><%= l(comment.created_at, format: :long) %></span>
         <% if comment.user == current_user %>
           <%= link_to t('views.common.edit'), polymorphic_url([commentable, comment], action: :edit) %>
           <%= link_to t('views.common.destroy'), polymorphic_url([commentable, comment]), method: :delete, data: { confirm: t('views.common.delete_confirm') } %>

--- a/app/views/users/_users.html.erb
+++ b/app/views/users/_users.html.erb
@@ -16,7 +16,7 @@
       <tr>
         <th>
           <% if user.avatar.attached? %>
-            <%= image_tag user.avatar.variant(resize_to_fill: [30, 30])%>
+            <%= image_tag user.avatar.variant(resize_to_fill: [30, 30]) %>
           <% end %>
         </th>
         <td><%= user.email %></td>

--- a/app/views/users/followers/index.html.erb
+++ b/app/views/users/followers/index.html.erb
@@ -1,5 +1,5 @@
 <h1><%= t('.title') %></h1>
 <p><%= User.model_name.human %>: <%= link_to @user.name, @user %></p>
 <%= render 'users/users', users: @followers %>
-<%= paginate @followers%>
+<%= paginate @followers %>
 <%= link_to t('views.common.back'), @user %>

--- a/app/views/users/followings/index.html.erb
+++ b/app/views/users/followings/index.html.erb
@@ -1,5 +1,5 @@
 <h1><%= t('.title') %></h1>
 <p><%= User.model_name.human %>: <%= link_to @user.name, @user %></p>
 <%= render 'users/users', users: @followings %>
-<%= paginate @followings%>
+<%= paginate @followings %>
 <%= link_to t('views.common.back'), @user %>

--- a/app/views/users/reports/index.html.erb
+++ b/app/views/users/reports/index.html.erb
@@ -1,15 +1,19 @@
 <h1><%= t('users.reports.index.title', name: @user.name) %></h1>
 
-<div class="reports_list">
-  <ul>
-    <% @reports.each do |report| %>
-    <li>
-      <%= link_to report.title, report %>
-      <span class="report_writer"><%= report.user.name %></span>
-    </li>
-    <% end %>
-  </ul>
-</div>
+<% if @reports.empty? %>
+  <p><%= t('users.reports.index.nothing') %></p>
+<% else %>
+  <div class="reports_list">
+    <ul>
+      <% @reports.each do |report| %>
+      <li>
+        <%= link_to report.title, report %>
+        <span class="report_writer"><%= report.user.name %></span>
+      </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
 
 <div>
   <%= paginate @reports %>

--- a/app/views/users/reports/index.html.erb
+++ b/app/views/users/reports/index.html.erb
@@ -1,0 +1,16 @@
+<h1><%= t('users.reports.index.title', name: @user.name) %></h1>
+
+<div class="reports_list">
+  <ul>
+    <% @reports.each do |report| %>
+    <li>
+      <%= link_to report.title, report %>
+      <span class="report_writer"><%= report.user.name%></span>
+    </li>
+    <% end %>
+  </ul>
+</div>
+
+<div>
+  <%= paginate @reports %>
+</div>

--- a/app/views/users/reports/index.html.erb
+++ b/app/views/users/reports/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('users.reports.index.title', name: @user.name) %></h1>
+<h1><%= t('users.reports.index.title', name: @user.attribute_present?(:name) ? @user.name : @user.email) %></h1>
 
 <% if @reports.empty? %>
   <p><%= t('users.reports.index.nothing') %></p>

--- a/app/views/users/reports/index.html.erb
+++ b/app/views/users/reports/index.html.erb
@@ -5,7 +5,7 @@
     <% @reports.each do |report| %>
     <li>
       <%= link_to report.title, report %>
-      <span class="report_writer"><%= report.user.name%></span>
+      <span class="report_writer"><%= report.user.name %></span>
     </li>
     <% end %>
   </ul>

--- a/app/views/users/reports/index.html.erb
+++ b/app/views/users/reports/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('users.reports.index.title', name: @user.attribute_present?(:name) ? @user.name : @user.email) %></h1>
+<h1><%= t('users.reports.index.title', name: @user.name_or_email) %></h1>
 
 <% if @reports.empty? %>
   <p><%= t('users.reports.index.nothing') %></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,7 +29,7 @@
   <strong><%= User.human_attribute_name(:avatar) %>:</strong>
   <% if @user.avatar.attached? %>
     <br>
-    <%= image_tag @user.avatar.variant(resize_to_fill: [150, 150])%>
+    <%= image_tag @user.avatar.variant(resize_to_fill: [150, 150]) %>
   <% end %>
 </p>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -38,6 +38,8 @@
   <li><%= link_to t('.followers', count: @user.followers.count), user_followers_path(@user) %></li>
 </ul>
 
+<p><%= link_to t('users.reports.index.title', name: @user.name), user_reports_path(@user) %></p>
+
 <% if current_user.following?(@user) %>
   <%= form_with(url: user_relationships_path(@user), method: :delete, local: true) do |f| %>
     <%= f.submit t('.destroy') %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -38,7 +38,7 @@
   <li><%= link_to t('.followers', count: @user.followers.count), user_followers_path(@user) %></li>
 </ul>
 
-<p><%= link_to t('users.reports.index.title', name: @user.attribute_present?(:name) ? @user.name : @user.email), user_reports_path(@user) %></p>
+<p><%= link_to t('users.reports.index.title', name: @user.name_or_email), user_reports_path(@user) %></p>
 
 <% if current_user.following?(@user) %>
   <%= form_with(url: user_relationships_path(@user), method: :delete, local: true) do |f| %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -38,7 +38,7 @@
   <li><%= link_to t('.followers', count: @user.followers.count), user_followers_path(@user) %></li>
 </ul>
 
-<p><%= link_to t('users.reports.index.title', name: @user.name), user_reports_path(@user) %></p>
+<p><%= link_to t('users.reports.index.title', name: @user.attribute_present?(:name) ? @user.name : @user.email), user_reports_path(@user) %></p>
 
 <% if current_user.following?(@user) %>
   <%= form_with(url: user_relationships_path(@user), method: :delete, local: true) do |f| %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module BooksApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.i18n.default_locale = :ja
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,12 +13,6 @@ module BooksApp
 
     config.i18n.default_locale = :ja
 
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
+    config.time_zone = 'Asia/Tokyo'
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -246,6 +246,7 @@ ja:
         title: 日報作成
       index:
         title: "%{name}さんの日報"
+        nothing: まだ日報を投稿していません
     comments:
       create: コメントする
       nothing: まだコメントはありません

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -204,6 +204,7 @@ ja:
       default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
+      date_only: "%Y年%m月%d日"
     pm: 午後
   views:
     common:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -219,6 +219,7 @@ ja:
       title_show: "%{name}の詳細"
       sign_out: ログアウト
       minimum_length: "%{length}文字以上"
+      not_permitted: その操作は許可されていません
     pagination:
       first: '最初'
       last: '最後'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -246,6 +246,9 @@ ja:
         title: 日報作成
       index:
         title: "%{name}さんの日報"
+    comments:
+      create: コメントする
+      nothing: まだコメントはありません
   controllers:
     common:
       notice_create: "%{name}が作成されました。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -244,6 +244,8 @@ ja:
     reports:
       new:
         title: 日報作成
+      index:
+        title: "%{name}さんの日報"
   controllers:
     common:
       notice_create: "%{name}が作成されました。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -241,6 +241,9 @@ ja:
     followers:
       index:
         title: フォロワー
+    reports:
+      new:
+        title: 日報作成
   controllers:
     common:
       notice_create: "%{name}が作成されました。"

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       book: 本  #g
       user: ユーザ
+      report: 日報
 
     attributes:
       book:
@@ -16,3 +17,6 @@ ja:
         address: 住所
         self_introduction: 自己紹介文
         avatar: ユーザ画像
+      report:
+        title: タイトル
+        content: 内容

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -4,6 +4,7 @@ ja:
       book: 本  #g
       user: ユーザ
       report: 日報
+      comment: コメント
 
     attributes:
       book:
@@ -19,4 +20,6 @@ ja:
         avatar: ユーザ画像
       report:
         title: タイトル
+        content: 内容
+      comment:
         content: 内容

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -21,5 +21,7 @@ ja:
       report:
         title: タイトル
         content: 内容
+        user_id: 投稿者
+        created_at: 投稿日
       comment:
         content: 内容

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
       resources :followers, only: [:index]
     end
   end
+  resources :reports
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :comments, only: %i[create edit update destroy], module: 'books'
   end
   resources :reports do
-    resources :comments, only: [:create], module: 'reports'
+    resources :comments, only: %i[create edit update destroy], module: 'reports'
   end
   resources :users, only: %i[index show] do
     resource :relationships, only: %i[create destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'books#index'
   resources :books do
-    resources :comments, only: %i[create edit update], module: 'books'
+    resources :comments, only: %i[create edit update destroy], module: 'books'
   end
   resources :reports do
     resources :comments, only: [:create], module: 'reports'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'books#index'
   resources :books do
-    resources :comments, only: [:create], module: 'books'
+    resources :comments, only: %i[create edit update], module: 'books'
   end
   resources :reports do
     resources :comments, only: [:create], module: 'reports'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       resources :followings, only: [:index]
       resources :followers, only: [:index]
     end
+    resources :reports, only: [:index], controller: 'users/reports'
   end
   resources :reports
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users
   root to: 'books#index'
-  resources :books
+  resources :books do
+    resources :comments, only: [:create], module: 'books'
+  end
   resources :users, only: %i[index show] do
     resource :relationships, only: %i[create destroy]
     scope module: :users do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   resources :books do
     resources :comments, only: [:create], module: 'books'
   end
+  resources :reports do
+    resources :comments, only: [:create], module: 'reports'
+  end
   resources :users, only: %i[index show] do
     resource :relationships, only: %i[create destroy]
     scope module: :users do
@@ -13,5 +16,4 @@ Rails.application.routes.draw do
     end
     resources :reports, only: [:index], controller: 'users/reports'
   end
-  resources :reports
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,6 @@ Rails.application.routes.draw do
       resources :followings, only: [:index]
       resources :followers, only: [:index]
     end
-    resources :reports, only: [:index], controller: 'users/reports'
+    resources :reports, only: [:index], module: 'users'
   end
 end

--- a/db/migrate/20220822222111_create_reports.rb
+++ b/db/migrate/20220822222111_create_reports.rb
@@ -1,0 +1,11 @@
+class CreateReports < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reports do |t|
+      t.string :title
+      t.text :content
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220824231908_create_comments.rb
+++ b/db/migrate/20220824231908_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.text :content, null: false
+      t.references :commentable, polymorphic: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_31_231050) do
+ActiveRecord::Schema.define(version: 2022_08_22_222111) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -58,6 +58,15 @@ ActiveRecord::Schema.define(version: 2021_05_31_231050) do
     t.index ["following_id"], name: "index_relationships_on_following_id"
   end
 
+  create_table "reports", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -76,4 +85,5 @@ ActiveRecord::Schema.define(version: 2021_05_31_231050) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_22_222111) do
+ActiveRecord::Schema.define(version: 2022_08_24_231908) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,17 @@ ActiveRecord::Schema.define(version: 2022_08_22_222111) do
     t.string "picture"
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.text "content", null: false
+    t.string "commentable_type"
+    t.integer "commentable_id"
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "relationships", force: :cascade do |t|
     t.integer "following_id", null: false
     t.integer "follower_id", null: false
@@ -85,5 +96,6 @@ ActiveRecord::Schema.define(version: 2022_08_22_222111) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "users"
   add_foreign_key "reports", "users"
 end


### PR DESCRIPTION
サンプルアプリに日報投稿機能とコメント投稿機能を追加しました。
ご確認をよろしくお願いいたします。

実装した要件は次になります。
1. 必須要件
    + 日報（reports）が投稿できるようにする（reportsのCRUDを作る。入力項目はタイトルと本文だけで良い。created_atの日付を日報の投稿日とする）
    + 日報を更新・削除できるのはその日報を投稿した本人のみ
    + 本と日報の各詳細画面からコメントを投稿できるようにする
    + 投稿したコメントは本と日報の各詳細画面から確認できる。投稿した内容、投稿したユーザーの名前（未入力ならメアド）、投稿日時を表示する

2. 歓迎要件
    + コメントが1件もない場合はその旨を画面に表示する
    + HTML5の必須チェックが効かない場合を考慮して、バリデーションエラー時のレスポンスも返せるようにする
    + コメントの編集と削除ができるようにする